### PR TITLE
feat(cli): add --year flag, change type of year to u32

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -1,12 +1,12 @@
 pub trait License {
-    fn notice(&self, year: i32, name: &str, project: &str) -> String;
+    fn notice(&self, year: u32, name: &str, project: &str) -> String;
 }
 
 // agpl-3.0.txt
 pub struct AGPL {}
 
 impl License for AGPL {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/agpl-3.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -15,7 +15,7 @@ impl License for AGPL {
 pub struct Apache {}
 
 impl License for Apache {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/apache-2.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -24,7 +24,7 @@ impl License for Apache {
 pub struct BSD {}
 
 impl License for BSD {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/bsd-3.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -33,7 +33,7 @@ impl License for BSD {
 pub struct CcBy {}
 
 impl License for CcBy {
-    fn notice(&self, _year: i32, name: &str, project: &str) -> String {
+    fn notice(&self, _year: u32, name: &str, project: &str) -> String {
         format!(include_str!("../files/cc-by-4.0.txt"), AUTHOR = name, PROJECT = project)
     }
 }
@@ -42,7 +42,7 @@ impl License for CcBy {
 pub struct CcByNc {}
 
 impl License for CcByNc {
-    fn notice(&self, _year: i32, name: &str, project: &str) -> String {
+    fn notice(&self, _year: u32, name: &str, project: &str) -> String {
         format!(include_str!("../files/cc-by-nc-4.0.txt"), AUTHOR = name, PROJECT = project)
     }
 }
@@ -51,7 +51,7 @@ impl License for CcByNc {
 pub struct CcByNcSa {}
 
 impl License for CcByNcSa {
-    fn notice(&self, _year: i32, name: &str, project: &str) -> String {
+    fn notice(&self, _year: u32, name: &str, project: &str) -> String {
         format!(include_str!("../files/cc-by-nc-sa-4.0.txt"), AUTHOR = name, PROJECT = project)
     }
 }
@@ -60,7 +60,7 @@ impl License for CcByNcSa {
 pub struct CcBySa {}
 
 impl License for CcBySa {
-    fn notice(&self, _year: i32, name: &str, project: &str) -> String {
+    fn notice(&self, _year: u32, name: &str, project: &str) -> String {
         format!(include_str!("../files/cc-by-sa-4.0.txt"), AUTHOR = name, PROJECT = project)
     }
 }
@@ -69,7 +69,7 @@ impl License for CcBySa {
 pub struct CCZero {}
 
 impl License for CCZero {
-    fn notice(&self, _year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, _year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/cc-zero-1.0.txt"), AUTHOR = name)
     }
 }
@@ -78,7 +78,7 @@ impl License for CCZero {
 pub struct GPL {}
 
 impl License for GPL {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/gpl-3.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -87,7 +87,7 @@ impl License for GPL {
 pub struct LGPL {}
 
 impl License for LGPL {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/lgpl-3.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -96,7 +96,7 @@ impl License for LGPL {
 pub struct Mit {}
 
 impl License for Mit {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/mit.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -105,7 +105,7 @@ impl License for Mit {
 pub struct MPL {}
 
 impl License for MPL {
-    fn notice(&self, year: i32, name: &str, _project: &str) -> String {
+    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
         format!(include_str!("../files/mpl-2.0.txt"), YEAR = year, AUTHOR = name)
     }
 }
@@ -114,7 +114,7 @@ impl License for MPL {
 pub struct UNLICENSE {}
 
 impl License for UNLICENSE {
-    fn notice(&self, _year: i32, _name: &str, _project: &str) -> String {
+    fn notice(&self, _year: u32, _name: &str, _project: &str) -> String {
         include_str!("../files/unlicense.txt").to_string()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,8 @@ struct Opt {
     author: String,
     #[structopt(long = "project")]
     project: Option<String>,
-    // TODO: --year support
-    // #[structopt(long = "year")]
-    // year: u32,
+    #[structopt(long = "year")]
+    year: Option<u32>,
 }
 
 fn main() -> Result<(), Box<std::error::Error>> {
@@ -33,6 +32,9 @@ fn main() -> Result<(), Box<std::error::Error>> {
     });
     let dt = Local::now();
     let current_year = dt.year();
+    let year = opt.year.unwrap_or_else(|| {
+        current_year as u32
+    });
     let author = opt.author.as_str();
     // TODO: want to remove clone
     let project = opt.project.clone().unwrap_or_else(|| {
@@ -46,7 +48,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     });
 
     let license_text = license.notice(
-        current_year,
+        year,
         &author,
         &project);
     write_license(&license_text, "LICENSE").unwrap_or_else(|error| {


### PR DESCRIPTION
Hi!

This PR is related to #8 .
With this change, the CLI gets supporting `--year` argument.

```bash
$ ./target/debug/license-generator --help
license-generator 0.4.0
azu <azuciao@gmail.com>
A Command line tool that generate `LICENSE` file.

USAGE:
    license-generator [OPTIONS] <INPUT> --author <author>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --author <author>
        --project <project>
        --year <year>

ARGS:
    <INPUT>
```