### PR TITLE
fix(license):  fix an issue where GitHub did not identify GPL-series licenses

### DIFF
--- a/files/agpl-3.0.txt
+++ b/files/agpl-3.0.txt
@@ -1,7 +1,7 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/files/agpl-3.0.txt
+++ b/files/agpl-3.0.txt
@@ -615,3 +615,47 @@ reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/files/agpl-3.0.txt
+++ b/files/agpl-3.0.txt
@@ -1,15 +1,3 @@
-Copyright (C) {YEAR} {AUTHOR}
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/files/gpl-3.0.txt
+++ b/files/gpl-3.0.txt
@@ -617,3 +617,58 @@ reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/files/gpl-3.0.txt
+++ b/files/gpl-3.0.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/files/gpl-3.0.txt
+++ b/files/gpl-3.0.txt
@@ -1,14 +1,3 @@
-Copyright (C) {YEAR} {AUTHOR}
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/files/lgpl-3.0.txt
+++ b/files/lgpl-3.0.txt
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/files/lgpl-3.0.txt
+++ b/files/lgpl-3.0.txt
@@ -1,15 +1,3 @@
-Copyright (C) {YEAR} {AUTHOR}
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3.0 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,8 @@ mod test {
         let gpl = create_license("gpl");
         let license_text = gpl.unwrap().notice(2018, "azu", "license-generator");
         assert!(license_text.contains("GNU GENERAL PUBLIC LICENSE"));
-        assert!(license_text.contains("azu"));
-        assert!(license_text.contains("2018"));
     }
+
     #[test]
     fn create_ccby_license() {
         let ccby = create_license("ccby");

--- a/src/license.rs
+++ b/src/license.rs
@@ -6,11 +6,9 @@ pub trait License {
 pub struct AGPL {}
 
 impl License for AGPL {
-    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
+    fn notice(&self, _year: u32, _name: &str, _project: &str) -> String {
         format!(
-            include_str!("../files/agpl-3.0.txt"),
-            YEAR = year,
-            AUTHOR = name
+            include_str!("../files/agpl-3.0.txt")
         )
     }
 }
@@ -106,11 +104,9 @@ impl License for CCZero {
 pub struct GPL {}
 
 impl License for GPL {
-    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
+    fn notice(&self, _year: u32, _name: &str, _project: &str) -> String {
         format!(
-            include_str!("../files/gpl-3.0.txt"),
-            YEAR = year,
-            AUTHOR = name
+            include_str!("../files/gpl-3.0.txt")
         )
     }
 }
@@ -119,11 +115,9 @@ impl License for GPL {
 pub struct LGPL {}
 
 impl License for LGPL {
-    fn notice(&self, year: u32, name: &str, _project: &str) -> String {
+    fn notice(&self, _year: u32, _name: &str, _project: &str) -> String {
         format!(
-            include_str!("../files/lgpl-3.0.txt"),
-            YEAR = year,
-            AUTHOR = name
+            include_str!("../files/lgpl-3.0.txt")
         )
     }
 }


### PR DESCRIPTION
Hi!
This PR is related to #20 .

Fixes an issue where GitHub does not recognize the license type of GPL-series by removing the license notices from the generated license file.

Also, to match the gnu.org license file, URL scheme has been changed and the license description has been added.

The diff command confirmed an exact match with the following.
- https://www.gnu.org/licenses/gpl-3.0.txt
- https://www.gnu.org/licenses/agpl-3.0.txt
- https://www.gnu.org/licenses/lgpl-3.0.txt